### PR TITLE
use fetch for json

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,12 @@
-import emails from './email-data.json'
+// import emails from './email-data.json'
 
 export class Index {
 
     constructor(){
-      console.log(emails.length);
+      // console.log(emails.length);
+      const url = './src/js/email-data.json'
+      fetch(url).then(r => r.json())
+      .then(emails => console.log(emails.length))
     }
   };
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Using webpack to handle the json bundles it all up in the.. bundle, so its quicker at load time, immediately accessible

the answer to solve the size issue, is to server render the json, with either node/express, rails or anything else

webpack-dev-server can do this, and we're already using it! it uses express under the hood anyway. So we can have it server rendered, and use fetch or axios to retrieve it, as an async action